### PR TITLE
Had forgotten to move combine_filled_orders() back to pk_utils.py

### DIFF
--- a/scripts/pk/pk_strategy.py
+++ b/scripts/pk/pk_strategy.py
@@ -15,6 +15,7 @@ from hummingbot.strategy_v2.executors.position_executor.data_types import Positi
 from hummingbot.strategy_v2.models.executors import CloseType
 from scripts.pk.pk_triple_barrier import TripleBarrier
 from scripts.pk.pk_utils import (
+    combine_filled_orders,
     compute_take_profit_price,
     has_current_price_reached_stop_loss,
     has_current_price_reached_take_profit,
@@ -270,49 +271,11 @@ class PkStrategy(StrategyV2Base):
             self.close_filled_order(filled_orders[0], market_or_limit, close_type)
             return
 
-        combined_order: TrackedOrderDetails = self.combine_filled_orders(filled_orders)
+        combined_order: TrackedOrderDetails = combine_filled_orders(filled_orders)
         self.close_filled_order(combined_order, market_or_limit, close_type)
 
         for filled_order in filled_orders:
             self.update_order_to_closed(filled_order.order_id, close_type, self.get_market_data_provider_time())
-
-    # TODO: move to pk_utils.py
-    def combine_filled_orders(self, filled_orders: List[TrackedOrderDetails]) -> TrackedOrderDetails:
-        non_terminated_filled_orders = [order for order in filled_orders if not order.terminated_at]
-        combined_filled_amount: Decimal = Decimal(0)
-
-        self.logger().info(f"combine_filled_orders | len(non_terminated_filled_orders): {len(non_terminated_filled_orders)}")
-
-        for order in non_terminated_filled_orders:
-            if order.side == TradeType.SELL:
-                combined_filled_amount -= order.filled_amount
-                self.logger().info(f"combine_filled_orders > order.side == TradeType.SELL | combined_filled_amount: {combined_filled_amount}")
-
-            else:
-                combined_filled_amount += order.filled_amount
-                self.logger().info(f"combine_filled_orders > order.side == TradeType.BUY | combined_filled_amount: {combined_filled_amount}")
-
-        first_order = filled_orders[0]
-
-        self.logger().info(f"combine_filled_orders | abs(combined_filled_amount): {abs(combined_filled_amount)}")
-
-        # TODO: remove intermediate var
-        result = TrackedOrderDetails(
-            connector_name=first_order.connector_name,
-            trading_pair=first_order.trading_pair,
-            side=TradeType.SELL if combined_filled_amount < 0 else TradeType.BUY,
-            order_id="combined",
-            amount=abs(combined_filled_amount),
-            entry_price=first_order.last_filled_price,
-            triple_barrier=first_order.triple_barrier,
-            ref=first_order.ref,
-            created_at=first_order.created_at,
-            filled_amount=abs(combined_filled_amount)
-        )
-
-        self.logger().info(f"combine_filled_orders | result:{result}")
-
-        return result
 
     def cancel_unfilled_order(self, tracked_order: TrackedOrderDetails):
         connector_name = tracked_order.connector_name

--- a/scripts/pk/pk_utils.py
+++ b/scripts/pk/pk_utils.py
@@ -126,6 +126,33 @@ def was_an_order_recently_opened(tracked_orders: List[TrackedOrderDetails], seco
     return most_recent_created_at + seconds > current_timestamp
 
 
+def combine_filled_orders(filled_orders: List[TrackedOrderDetails]) -> TrackedOrderDetails:
+    non_terminated_filled_orders = [order for order in filled_orders if not order.terminated_at]
+    combined_filled_amount: Decimal = Decimal(0)
+
+    for order in non_terminated_filled_orders:
+        if order.side == TradeType.SELL:
+            combined_filled_amount -= order.filled_amount
+
+        else:
+            combined_filled_amount += order.filled_amount
+
+    first_order = filled_orders[0]
+
+    return TrackedOrderDetails(
+        connector_name=first_order.connector_name,
+        trading_pair=first_order.trading_pair,
+        side=TradeType.SELL if combined_filled_amount < 0 else TradeType.BUY,
+        order_id="combined",
+        amount=abs(combined_filled_amount),
+        entry_price=first_order.last_filled_price,
+        triple_barrier=first_order.triple_barrier,
+        ref=first_order.ref,
+        created_at=first_order.created_at,
+        filled_amount=abs(combined_filled_amount)
+    )
+
+
 def timestamp_to_iso(timestamp: float) -> str:
     return datetime.fromtimestamp(timestamp).isoformat()
 


### PR DESCRIPTION
This pull request includes refactoring changes to the `scripts/pk/pk_strategy.py` and `scripts/pk/pk_utils.py` files to improve code organization and maintainability. The most important changes involve moving the `combine_filled_orders` function to a more appropriate file and updating references accordingly.

Code organization improvements:

* [`scripts/pk/pk_strategy.py`](diffhunk://#diff-22241b330802df2ef82d880b11b861ef1fc8ce74a0e3faa82c3fa618224a7884L273-L316): Removed the `combine_filled_orders` method and updated the `close_filled_orders` method to use the `combine_filled_orders` function from `pk_utils.py`.
* [`scripts/pk/pk_utils.py`](diffhunk://#diff-66afcd7d7f5d42586eb2fc44e6c1b425905488f3739ad9df083235c11ebbbcf8R129-R155): Added the `combine_filled_orders` function to this file, which now handles the logic for combining filled orders.
* [`scripts/pk/pk_strategy.py`](diffhunk://#diff-22241b330802df2ef82d880b11b861ef1fc8ce74a0e3faa82c3fa618224a7884R18): Imported the `combine_filled_orders` function from `pk_utils.py` to ensure it can be used within this file.